### PR TITLE
Fixes for latest nightly docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org/"
+
+gem "execjs"
+gem "nokogiri"
+
+group :development do
+  gem "pry"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,22 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.0)
+    execjs (2.0.2)
+    method_source (0.8.2)
+    mini_portile (0.5.2)
+    nokogiri (1.6.1)
+      mini_portile (~> 0.5.0)
+    pry (0.9.12.6)
+      coderay (~> 1.0)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+    slop (3.4.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  execjs
+  nokogiri
+  pry

--- a/Info.plist
+++ b/Info.plist
@@ -3,11 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
-	<string>Rust</string>
+	<string>rust-nightly</string>
 	<key>CFBundleName</key>
-	<string>Rust</string>
+	<string>Rust Nightly</string>
 	<key>DocSetPlatformFamily</key>
-	<string>Rust</string>
+	<string>rust</string>
 	<key>isDashDocset</key>
 	<true/>
   <key>dashIndexFilePath</key>

--- a/Info.plist
+++ b/Info.plist
@@ -12,5 +12,7 @@
 	<true/>
   <key>dashIndexFilePath</key>
   <string>index.html</string>
+  <key>DashDocSetFamily</key>
+  <string>dashtoc2</string>
 </dict>
 </plist>

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,8 @@ require 'rubygems'
 require 'bundler/setup'
 require './lib/docset_index'
 require './lib/docset_theme'
+require './lib/docset_fetch_assets'
+require './lib/docset_replace_assets'
 
 task :default => %w(docset)
 
@@ -11,7 +13,9 @@ task :docset => [
   "Rust.docset/Contents/Info.plist",
   "Rust.docset/Contents/Resources/Documents",
   "docset:index",
-  "docset:theme"
+  "docset:theme",
+  "docset:assets:fetch",
+  "docset:assets:replace"
 ]
 
 directory "Rust.docset/Contents/Resources"
@@ -83,6 +87,24 @@ namespace :docset do
     cp File.join(doc_path, "main.css.orig"), File.join(doc_path, "main.css")
     rm File.join(doc_path, "main.css.orig")
     Rake::Task["docset:theme"].invoke
+  end
+
+  namespace :assets do
+    doc_path = "Rust.docset/Contents/Resources/Documents"
+    stylesheet = File.expand_path(File.join(doc_path, "main.css"))
+    asset_path = File.expand_path(File.join(doc_path, "_assets"))
+
+    desc "Fetch remote assets"
+    task :fetch do
+      mkdir_p asset_path
+
+      DocsetFetchAssets.new(stylesheet, asset_path).save
+    end
+
+    desc "Replace references to remote assets with local ones"
+    task :replace => FileList[File.join(asset_path, "fonts", "*.woff")] do
+      DocsetReplaceAssets.new(stylesheet).save
+    end
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'bundler/setup'
 require './lib/docset_index'
+require './lib/docset_theme'
 
 task :default => %w(docset)
 
@@ -9,7 +10,8 @@ task :docset => [
   "Rust.docset/icon.png",
   "Rust.docset/Contents/Info.plist",
   "Rust.docset/Contents/Resources/Documents",
-  "docset:index"
+  "docset:index",
+  "docset:theme"
 ]
 
 directory "Rust.docset/Contents/Resources"
@@ -43,6 +45,16 @@ file "Rust.docset/Contents/Resources/Documents" => [
   cp_r local_docs, "Rust.docset/Contents/Resources/Documents"
 end
 
+file "Rust.docset/Contents/Resources/Documents/main.css.orig" => [
+  "Rust.docset/Contents/Resources/Documents"
+] do
+  doc_path = "Rust.docset/Contents/Resources/Documents"
+  stylesheet = File.join(doc_path, "main.css")
+  cp stylesheet, "#{stylesheet}.orig"
+
+  DocsetTheme.new(stylesheet).save
+end
+
 file "Rust.docset/Contents/Resources/docSet.dsidx" => [
   "Rust.docset/Contents/Resources"
 ] do
@@ -59,6 +71,18 @@ namespace :docset do
   task :reindex do
     rm_rf "Rust.docset/Contents/Resources/docSet.dsidx"
     Rake::Task["docset:index"].invoke
+  end
+
+  desc "Apply some Dash-friendly CSS to the docs stylesheet"
+  task :theme => [
+    "Rust.docset/Contents/Resources/Documents/main.css.orig"
+  ]
+
+  task :retheme do
+    doc_path = "Rust.docset/Contents/Resources/Documents"
+    cp File.join(doc_path, "main.css.orig"), File.join(doc_path, "main.css")
+    rm File.join(doc_path, "main.css.orig")
+    Rake::Task["docset:theme"].invoke
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+require 'rubygems'
+require 'bundler/setup'
 require './lib/docset_index'
 
 task :default => %w(docset)
@@ -28,6 +30,7 @@ file "Rust.docset/Contents/Resources/Documents" => [
   "Rust.docset/Contents/Resources"
 ] do
   local_docs = [
+    File.expand_path("~/Desktop/rust-nightly-x86_64-unknown-linux-gnu/doc"),
     File.expand_path("~/src/mozilla/rust/doc"),
     ENV['RUST_DOCS']
   ].find{|path| path && File.exist?(path) }

--- a/lib/docset_fetch_assets.rb
+++ b/lib/docset_fetch_assets.rb
@@ -1,0 +1,42 @@
+class DocsetFetchAssets
+  def initialize(stylesheet, dest_path)
+    @stylesheet = stylesheet
+    @dest_path = dest_path
+  end
+
+  def save
+    puts "Fetching remote assets..."
+    urls = find_remote_assets
+    urls.each { |u| download_asset(u) }
+  end
+
+  def find_remote_assets
+    open(@stylesheet, "r:UTF-8") do |f|
+      f.each_line.reduce(Set.new) do |found, line|
+        match = line.match(/url\("(http:\/\/.*)"\)/)
+        if match.nil?
+          found
+        else
+          found + [match[1]]
+        end
+      end
+    end
+  end
+
+  def download_asset(url_str)
+    require 'uri'
+    require 'open-uri'
+
+    url = URI.parse(url_str)
+    dest_path = File.join(@dest_path, url.path)
+    FileUtils.mkdir_p(File.dirname(dest_path))
+
+    puts "Fetching #{url.path} to #{@dest_path}"
+
+    open(url) do |src|
+      File.open(dest_path, "wb") do |dest|
+        dest.write src.read
+      end
+    end
+  end
+end

--- a/lib/docset_index.rb
+++ b/lib/docset_index.rb
@@ -55,7 +55,7 @@ class DocsetIndex
     Dir["#{@dir}/**/search-index.js"].each do |jsfile|
       puts "Indexing #{jsfile.split("/")[-2]}..."
 
-      items, paths = File.read(jsfile).
+      items, paths = File.open(jsfile, "r:UTF-8", &:read).
         scan(/(?:searchIndex|allPaths) \= (.*?)(?:;var|;$)/).
         flatten.
         map{|js| js.gsub("},{", "},\n{") }.

--- a/lib/docset_index.rb
+++ b/lib/docset_index.rb
@@ -57,10 +57,9 @@ class DocsetIndex
     # Parse and index guides from the docs root
     rustdoc = Nokogiri::HTML(File.read("#{@dir}/index.html"))
     [
-      "body > ul > li",
-      "section#guides li",
-      "section#tooling li",
-      "section#faq li",
+      "#guides + ul li",
+      "#tooling + ul li",
+      "#faqs + ul li",
     ].each do |selector|
       rustdoc.css(selector).each do |item|
         link = item.css("a").first

--- a/lib/docset_index.rb
+++ b/lib/docset_index.rb
@@ -2,16 +2,17 @@ class DocsetIndex
   DASH_TYPE = {
     "enum" => "Enum",
     "ffi" => "Function",
+    "ffs" => "Constant",
     "fn" => "Function",
     "method" => "Method",
     "mod" => "Module",
     "static" => "Constant",
-    "struct" => "Class",
-    "structfield" => "Attribute",
-    "trait" => "Protocol",
+    "struct" => "_Struct",
+    "structfield" => "Field",
+    "trait" => "Trait",
     "tymethod" => "Method",
     "typedef" => "Type",
-    "variant" => "Option",
+    "variant" => "Variant",
     "macro" => "Macro"
   }
 

--- a/lib/docset_index.rb
+++ b/lib/docset_index.rb
@@ -109,6 +109,8 @@ class DocsetIndex
       end
 
       items.each do |i|
+        parent = nil
+
         if i["parent"]
           parent = paths[i["parent"]]
           next if parent.nil?
@@ -127,11 +129,11 @@ class DocsetIndex
           end
         end
 
-        if i["ty"] == "fn"
-          name = [i["path"], i["name"]].join("::")
-        else
-          name = i["name"]
-        end
+        name = if parent.nil?
+                 [i["path"], i["name"]].join("::")
+               else
+                 [i["path"], parent["name"], i["name"]].compact.join("::")
+               end
 
         add name, DASH_TYPE[i["ty"]], path.gsub("::", "/")
       end

--- a/lib/docset_index.rb
+++ b/lib/docset_index.rb
@@ -154,7 +154,7 @@ private
     p [name, type, path] if @debug
 
     if type.nil?
-      puts "UNKNOWN TYPE #{type}"
+      puts "UNKNOWN TYPE for #{name} (#{path})"
     else
       # Sqlite3 single quote escape is two single quotes
       [name, type, path].each{|arg| arg.to_s.gsub!("'", "''") }

--- a/lib/docset_replace_assets.rb
+++ b/lib/docset_replace_assets.rb
@@ -1,0 +1,28 @@
+class DocsetReplaceAssets
+  def initialize(stylesheet)
+    @stylesheet = stylesheet
+  end
+
+  def save
+    replace_remote_assets
+  end
+
+  def replace_remote_assets
+    puts "opening #{@stylesheet}"
+    open(@stylesheet, "r+:UTF-8") do |f|
+      lines = f.each_line.map do |line|
+        line.gsub(/url\("(http:\/\/.*)"\)/) do |x|
+          url = URI.parse($1)
+          path = File.join("_assets", url.path)
+          replace = %{url("#{path}")}
+          puts "Replacing #{x} with #{replace}"
+          replace
+        end
+      end
+
+      f.rewind
+      len = f.write(lines.join(""))
+      f.truncate(len)
+    end
+  end
+end

--- a/lib/docset_theme.rb
+++ b/lib/docset_theme.rb
@@ -1,0 +1,26 @@
+class DocsetTheme
+  def initialize(stylesheet)
+    @stylesheet = stylesheet
+    @debug = true if ENV['DEBUG']
+  end
+
+  def save
+    append_styles
+  end
+
+  protected
+
+  def append_styles
+    puts "Applying Docset style overrides..."
+    open(@stylesheet, "a:UTF-8") do |f|
+      f.write <<-CSS
+
+
+/* Dash DocSet overrides */
+
+.sidebar, .sub { display: none; }
+.content { margin-left: 0; }
+CSS
+    end
+  end
+end


### PR DESCRIPTION
Wanted to give you a heads up that I'm working on updating this generator for the nightlies (though it's not quite ready yet). I know Dash ships with Rust documentation now, but unfortunately they become out of date rather quickly since they are only updated when Rust puts out a new official release. A number of changes were made to `rustdoc` since this repository was updated, and these fixes should reflect those.

Things left to do include:
- [x] Need to bundle and replace references to the online assets (fonts, logo) referenced in the Rust documentation.
- [x] I'd like to update the mapping of rustdoc item types to Dash item types, since I think Dash has added some more appropriate ones (like the Variant type, as one example).
- [x] More (all?) item names should be scoped to their crate and module, as the official Dash docset does.
- [x] Maybe the name of the docset should be changed to differentiate from the one shipped with Dash.
- [ ] TOC for items
- [x] Clean up HTML/CSS (remove sidebar/search area, remove " - Rust" from `<title>`)
