### PR TITLE
Check whether user-supplied path is a rust doc directory

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,6 +44,15 @@ file "Rust.docset/Contents/Resources/Documents" => [
     gets.chomp
   end
 
+  if !File.exist?(local_docs + "/index.html")
+    if File.exist?(local_docs + "/doc/index.html")
+		local_docs += "/doc"
+	else
+		puts "Path " + local_docs + " is not a rust doc directory!"
+		exit 1
+	end
+  end
+
   cp_r local_docs, "Rust.docset/Contents/Resources/Documents"
 end
 


### PR DESCRIPTION
From discussion at issue #5.

I've barely ever used Ruby, so the code might not be fully idiomatic; I do prefer the "if !..." to "unless ...", though, since there is an else branch.

So this really improves two things IMO: one, it refuses to copy any directory the user specifies (previously it would attempt to copy even /), and two, if the _root_ of a rust source directory is specified, it auto-corrects to the doc directory.
