### PR TITLE
Fix Enum indexing

### DIFF
--- a/lib/docset_index.rb
+++ b/lib/docset_index.rb
@@ -1,6 +1,5 @@
 class DocsetIndex
   DASH_TYPE = {
-    "enum" => "Enum",
     "ffi" => "Function",
     "ffs" => "Constant",
     "fn" => "Function",
@@ -11,7 +10,7 @@ class DocsetIndex
     "structfield" => "Field",
     "trait" => "Trait",
     "tymethod" => "Method",
-    "typedef" => "Type",
+    "type" => "Type",
     "variant" => "Variant",
     "macro" => "Macro"
   }
@@ -19,9 +18,9 @@ class DocsetIndex
   ITEM_TYPE = {
     0 => "mod",
     1 => "struct",
-    2 => "enum",
+    2 => "type",
     3 => "fn",
-    4 => "typedef",
+    4 => "type",
     5 => "static",
     6 => "trait",
     7 => "impl",


### PR DESCRIPTION
A change in the JS indexing is now reflected in the Ruby list.

We should consider trying to get all of this data represented as JSON so we can just load it in and call it a day. Protip™ to rust-doc: JavaScript supports JSON :smile:
